### PR TITLE
chore(release): bump version to 0.1.3

### DIFF
--- a/src/CSharp/DevPossible.Ton/DevPossible.Ton.csproj
+++ b/src/CSharp/DevPossible.Ton/DevPossible.Ton.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>DevPossible.Ton</PackageId>
-    <Version>0.1.2</Version>
+    <Version>0.1.3</Version>
     <Authors>DevPossible, LLC</Authors>
     <Company>DevPossible, LLC</Company>
     <Product>DevPossible.Ton</Product>
@@ -27,7 +27,7 @@
     <AssemblyCopyright>Copyright © 2024 DevPossible, LLC</AssemblyCopyright>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
-    <PackageVersion>0.1.2</PackageVersion>
+    <PackageVersion>0.1.3</PackageVersion>
 
     <!-- Contact Information -->
     <PackageOwners>DevPossible, LLC</PackageOwners>
@@ -35,6 +35,7 @@
   </PropertyGroup>
 
 </Project>
+
 
 
 

--- a/src/JavaScript/devpossible-ton/package.json
+++ b/src/JavaScript/devpossible-ton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devpossible/ton",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "JavaScript library for parsing, validating, and serializing TON (Text Object Notation) files. Full specification at https://tonspec.com. ALPHA RELEASE: Core functionality is complete but API may change before stable 1.0 release.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/Python/devpossible_ton/setup.py
+++ b/src/Python/devpossible_ton/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="devpossible-ton",
-    version="0.1.2",
+    version="0.1.3",
     author="DevPossible, LLC",
     author_email="support@devpossible.com",
     description="Python library for parsing, validating, and serializing TON (Text Object Notation) files. Full specification at https://tonspec.com. ALPHA RELEASE: Core functionality is complete but API may change before stable 1.0 release.",
@@ -56,6 +56,7 @@ setup(
         ],
     },
 )
+
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "library_version": "0.1.2",
+  "library_version": "0.1.3",
   "ton_spec_version": "1.0",
   "description": "Centralized version file for all DevPossible.Ton packages. library_version is for the package, ton_spec_version is for the TON file format specification."
 }


### PR DESCRIPTION
Version bump from 0.1.2 to 0.1.3 across all package implementations:
- C# NuGet package (DevPossible.Ton.csproj)
- JavaScript/NPM package (@devpossible/ton)
- Python package (devpossible-ton)
- Centralized version.json