### PR TITLE
chore: release v0.1.8 with documentation improvements

### DIFF
--- a/doc/doc-html/index.html
+++ b/doc/doc-html/index.html
@@ -126,9 +126,30 @@
                     <li><strong>Comments</strong>: Single-line (//, #) and multi-line (/* */) comments for documentation</li>
                 </ul>
 
-                <h2>Quick Example</h2>
+                <h2>Quick Examples</h2>
+                
+                <h3>Simple Example</h3>
+                <p>A basic object with string and integer properties - no class specifications or schema:</p>
                 <div class="code-block-wrapper">
-                    <pre><code class="language-ton">{(user)
+                    <pre><code class="language-ton">{
+    name = "Alice Smith",
+    title = "Software Engineer",
+    department = "Engineering",
+    location = "San Francisco",
+    yearsExperience = 5
+}</code></pre>
+                </div>
+
+                <h3>Complex Example</h3>
+                <p>Advanced features including class specification, type annotations, arrays, enums, multi-line strings, and schema validation:</p>
+                <div class="code-block-wrapper">
+                    <pre><code class="language-ton">@ {
+    title = "User Profile",
+    version = "1.0",
+    author = "DevPossible"
+}
+
+{(user)
     id = 12345,
     name = "John Doe",
     email = "john@example.com",

--- a/doc/doc-html/js/site.js
+++ b/doc/doc-html/js/site.js
@@ -20,6 +20,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Smooth scroll for anchor links
     initializeSmoothScroll();
+
+    // Hide tonspec.com alert if already on tonspec.com
+    hideTonspecAlertIfOnTonspec();
 });
 
 // Add copy buttons to all code blocks
@@ -265,6 +268,21 @@ function initializeMobileSidebar() {
             menuButton.style.display = 'block';
         }
     });
+}
+
+// Hide the tonspec.com alert panel if we're already on tonspec.com
+function hideTonspecAlertIfOnTonspec() {
+    // Check if the current hostname is tonspec.com
+    if (window.location.hostname === 'tonspec.com' || window.location.hostname === 'www.tonspec.com') {
+        // Find all alert divs and check if they contain the tonspec.com link
+        const alerts = document.querySelectorAll('.alert.alert-info');
+        alerts.forEach(alert => {
+            const tonspecLink = alert.querySelector('a[href="https://tonspec.com"]');
+            if (tonspecLink) {
+                alert.style.display = 'none';
+            }
+        });
+    }
 }
 
 // Smooth scroll for anchor links

--- a/src/CSharp/DevPossible.Ton/DevPossible.Ton.csproj
+++ b/src/CSharp/DevPossible.Ton/DevPossible.Ton.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>DevPossible.Ton</PackageId>
-    <Version>0.1.7</Version>
+    <Version>0.1.8</Version>
     <Authors>DevPossible, LLC</Authors>
     <Company>DevPossible, LLC</Company>
     <Product>DevPossible.Ton</Product>
@@ -27,7 +27,7 @@
     <AssemblyCopyright>Copyright © 2024 DevPossible, LLC</AssemblyCopyright>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
-    <PackageVersion>0.1.7</PackageVersion>
+    <PackageVersion>0.1.8</PackageVersion>
 
     <!-- Contact Information -->
     <PackageOwners>DevPossible, LLC</PackageOwners>
@@ -39,5 +39,6 @@
   </ItemGroup>
 
 </Project>
+
 
 

--- a/src/CSharp/DevPossible.Ton/README.md
+++ b/src/CSharp/DevPossible.Ton/README.md
@@ -22,7 +22,7 @@ Install-Package DevPossible.Ton
 ### Via PackageReference
 
 ```xml
-<PackageReference Include="DevPossible.Ton" Version="0.1.7" />
+<PackageReference Include="DevPossible.Ton" Version="0.1.8" />
 ```
 
 ## Quick Start
@@ -234,5 +234,6 @@ TON Specification: [tonspec.com](https://tonspec.com)
 ---
 
 **© 2024 DevPossible, LLC. All rights reserved.**
+
 
 

--- a/src/JavaScript/devpossible-ton/package.json
+++ b/src/JavaScript/devpossible-ton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devpossible/ton",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "JavaScript library for parsing, validating, and serializing TON (Text Object Notation) files. Full specification at https://tonspec.com. ALPHA RELEASE: Core functionality is complete but API may change before stable 1.0 release.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/Python/devpossible_ton/setup.py
+++ b/src/Python/devpossible_ton/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="devpossible-ton",
-    version="0.1.7",
+    version="0.1.8",
     author="DevPossible, LLC",
     author_email="support@devpossible.com",
     description="Python library for parsing, validating, and serializing TON (Text Object Notation) files. Full specification at https://tonspec.com. ALPHA RELEASE: Core functionality is complete but API may change before stable 1.0 release.",
@@ -56,6 +56,7 @@ setup(
         ],
     },
 )
+
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "library_version": "0.1.7",
+  "library_version": "0.1.8",
   "ton_spec_version": "1.0",
   "description": "Centralized version file for all DevPossible.Ton packages. library_version is for the package, ton_spec_version is for the TON file format specification."
 }


### PR DESCRIPTION
- Add simple example to documentation showcasing basic TON syntax
- Reorganize examples section into Simple and Complex categories
- Hide redundant tonspec.com alert when already on tonspec.com domain
- Bump package versions from 0.1.7 to 0.1.8 across C# and JavaScript
- Fix missing newlines at end of files